### PR TITLE
Improve login test to verify token body

### DIFF
--- a/src/test/java/com/morpheus/controller/AuthenticationControllerTest.java
+++ b/src/test/java/com/morpheus/controller/AuthenticationControllerTest.java
@@ -38,7 +38,13 @@ class AuthenticationControllerTest {
         TokenResponse tokenResponse = new TokenResponse("fake-jwt-token");
         Mockito.when(authenticationService.authenticate(any(LoginRequest.class))).thenReturn(tokenResponse);
 
-        mockMvc.perform(post("/auth/login").contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(loginRequest))).andExpect(status().isOk());
+        org.springframework.test.web.servlet.MvcResult result = mockMvc
+                .perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(tokenResponse)))
+                .andReturn();
     }
 
     @Test


### PR DESCRIPTION
## Summary
- enhance login test to capture the response and validate returned token

## Testing
- `mvn -v` *(fails: command not found)*
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d6de42fdc8327a55ff2007a373777