### PR TITLE
Fix scheduler lookback

### DIFF
--- a/src/main/java/com/morpheus/repository/EventRepository.java
+++ b/src/main/java/com/morpheus/repository/EventRepository.java
@@ -16,4 +16,11 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     List<Event> findByScheduledForBetween(LocalDateTime start, LocalDateTime end);
 
     List<Event> findByNotifiedFalseAndScheduledForBefore(LocalDateTime time);
+
+    /**
+     * Busca eventos não notificados agendados entre os intervalos informados.
+     * Utilizado pelo agendador para evitar perda de eventos durante
+     * reinícios ou períodos de inatividade.
+     */
+    List<Event> findByNotifiedFalseAndScheduledForBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/morpheus/service/EventSchedulerService.java
+++ b/src/main/java/com/morpheus/service/EventSchedulerService.java
@@ -43,9 +43,11 @@ public class EventSchedulerService {
         }
 
         final LocalDateTime now = LocalDateTime.now();
+        final LocalDateTime lookbackStart = now.minusMinutes(lookbackMinutes);
         try {
-            final List<Event> pendingEvents = eventRepository.findByNotifiedFalseAndScheduledForBefore(now);
-            log.info("Verificando eventos agendados até {}. Encontrados: {}", now, pendingEvents.size());
+            final List<Event> pendingEvents = eventRepository
+                    .findByNotifiedFalseAndScheduledForBetween(lookbackStart, now);
+            log.info("Verificando eventos agendados de {} até {}. Encontrados: {}", lookbackStart, now, pendingEvents.size());
             int notifiedCount = notifyAndMarkEvents(pendingEvents);
             log.info("Total de eventos notificados nesta execução: {}", notifiedCount);
         } catch (Exception e) {

--- a/src/test/java/com/morpheus/service/EventSchedulerServiceTest.java
+++ b/src/test/java/com/morpheus/service/EventSchedulerServiceTest.java
@@ -52,13 +52,13 @@ class EventSchedulerServiceTest {
         field.setAccessible(true);
         field.set(eventSchedulerService, false);
         eventSchedulerService.checkScheduledEvents();
-        verify(eventRepository, never()).findByNotifiedFalseAndScheduledForBefore(any());
+        verify(eventRepository, never()).findByNotifiedFalseAndScheduledForBetween(any(), any());
     }
 
     @Test
     void checkScheduledEvents_pendingEventsAreNotifiedAndSaved() {
         Event event = mock(Event.class);
-        when(eventRepository.findByNotifiedFalseAndScheduledForBefore(any(LocalDateTime.class))).thenReturn(List.of(event));
+        when(eventRepository.findByNotifiedFalseAndScheduledForBetween(any(LocalDateTime.class), any(LocalDateTime.class))).thenReturn(List.of(event));
         when(event.getUser()).thenReturn(null);
         when(event.getTitle()).thenReturn("Título teste");
         when(event.getId()).thenReturn(1L);
@@ -84,7 +84,7 @@ class EventSchedulerServiceTest {
 
     @Test
     void checkScheduledEvents_exceptionOnQuery_logsError() {
-        when(eventRepository.findByNotifiedFalseAndScheduledForBefore(any(LocalDateTime.class))).thenThrow(new RuntimeException("Database error"));
+        when(eventRepository.findByNotifiedFalseAndScheduledForBetween(any(LocalDateTime.class), any(LocalDateTime.class))).thenThrow(new RuntimeException("Database error"));
         eventSchedulerService.checkScheduledEvents();
         verify(eventRepository, never()).saveAll(any());
     }


### PR DESCRIPTION
## Summary
- prevent missed events by using lookback interval
- add repository method for lookback queries
- update scheduler service and tests

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d62d1e43883278c66048887f61f53