### PR TITLE
Fix JWT role parsing

### DIFF
--- a/src/main/java/com/morpheus/security/JwtTokenProvider.java
+++ b/src/main/java/com/morpheus/security/JwtTokenProvider.java
@@ -11,6 +11,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.util.Date;
 import java.util.List;
+import java.util.Arrays;
 
 @Component
 @RequiredArgsConstructor
@@ -58,7 +59,7 @@ public class JwtTokenProvider {
         Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
         Object rolesClaim = claims.get("roles");
         if (rolesClaim instanceof String rolesStr) {
-            return List.of(rolesStr.split(","));
+            return Arrays.asList(rolesStr.split(","));
         } else if (rolesClaim instanceof java.util.Collection<?> rolesCol) {
             return rolesCol.stream().map(Object::toString).toList();
         }

--- a/src/test/java/com/morpheus/security/JwtTokenProviderTest.java
+++ b/src/test/java/com/morpheus/security/JwtTokenProviderTest.java
@@ -43,5 +43,17 @@ class JwtTokenProviderTest {
         String invalidToken = "invalid.token.value";
         assertFalse(jwtTokenProvider.validateToken(invalidToken));
     }
+
+    @Test
+    void shouldParseMultipleRoles() {
+        String subject = "testUser";
+        var token = jwtTokenProvider.generateToken(subject, java.util.List.of("ADMIN", "USER"));
+        assertTrue(jwtTokenProvider.validateToken(token));
+        assertEquals(subject, jwtTokenProvider.getSubject(token));
+        var roles = jwtTokenProvider.getRoles(token);
+        assertEquals(2, roles.size());
+        assertTrue(roles.contains("ADMIN"));
+        assertTrue(roles.contains("USER"));
+    }
 }
 


### PR DESCRIPTION
## Summary
- use `Arrays.asList` when parsing the roles claim
- include missing `Arrays` import
- test parsing of multiple roles

## Testing
- `mvn test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d789df72c83278f827d26c214deaa