### PR TITLE
Improve EventControllerTest assertions

### DIFF
--- a/src/test/java/com/morpheus/controller/EventControllerTest.java
+++ b/src/test/java/com/morpheus/controller/EventControllerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @WebMvcTest(EventController.class)
 class EventControllerTest {
@@ -46,7 +47,12 @@ class EventControllerTest {
         Mockito.when(authentication.getPrincipal()).thenReturn("user@email.com");
         Mockito.when(eventService.listEvents("user@email.com")).thenReturn(events);
 
-        mockMvc.perform(get("/events").principal(authentication)).andExpect(status().isOk());
+        org.springframework.test.web.servlet.MvcResult result = mockMvc
+                .perform(get("/events").principal(authentication))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertEquals(objectMapper.writeValueAsString(events), result.getResponse().getContentAsString());
     }
 
     @Test
@@ -57,6 +63,14 @@ class EventControllerTest {
         Mockito.when(authentication.getPrincipal()).thenReturn("user@email.com");
         Mockito.when(eventService.createEvent(eq("user@email.com"), any(EventRequest.class))).thenReturn(eventResponse);
 
-        mockMvc.perform(post("/events").principal(authentication).contentType(MediaType.APPLICATION_JSON).content(objectMapper.writeValueAsString(eventRequest))).andExpect(status().isCreated());
+        org.springframework.test.web.servlet.MvcResult result = mockMvc
+                .perform(post("/events")
+                        .principal(authentication)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(eventRequest)))
+                .andExpect(status().isCreated())
+                .andReturn();
+
+        assertEquals(objectMapper.writeValueAsString(eventResponse), result.getResponse().getContentAsString());
     }
 }


### PR DESCRIPTION
## Summary
- enhance EventController tests to check response bodies

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d78b9b70c8327b4b727e654634fc3